### PR TITLE
security: fix CORS misconfiguration — restrict allowed origins

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,7 +33,11 @@ class Settings:
     MAX_CONVERSATION_HISTORY: int = int(os.getenv("MAX_CONVERSATION_HISTORY", "50"))
     ENABLE_DEBUG_LOGS: bool = os.getenv("ENABLE_DEBUG_LOGS", "false").lower() == "true"
     ALLOWED_HOSTS: List[str] = os.getenv("ALLOWED_HOSTS", "*").split(",")
-    ALLOWED_ORIGINS: List[str] = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+    # SECURITY: Default origins restricted to localhost for local development.
+    # Set ALLOWED_ORIGINS env var to a comma-separated list of trusted origins
+    # (e.g. "https://chat.example.com,https://app.example.com").
+    # Using wildcard "*" with allow_credentials=True is insecure (CORS spec violation).
+    ALLOWED_ORIGINS: List[str] = os.getenv("ALLOWED_ORIGINS", "http://localhost:8000,http://localhost:3000").split(",")
     
     # Research/Logging Configuration
     CHAT_LOG: str = os.getenv("CHAT_LOG", "")

--- a/app/config.py
+++ b/app/config.py
@@ -33,22 +33,21 @@ class Settings:
     MAX_CONVERSATION_HISTORY: int = int(os.getenv("MAX_CONVERSATION_HISTORY", "50"))
     ENABLE_DEBUG_LOGS: bool = os.getenv("ENABLE_DEBUG_LOGS", "false").lower() == "true"
     ALLOWED_HOSTS: List[str] = os.getenv("ALLOWED_HOSTS", "*").split(",")
-    # SECURITY: CORS allowed origins.
-    # Default: localhost only (safe for local development).
-    # Override with ALLOWED_ORIGINS env var — comma-separated list of trusted origins.
+    # CORS allowed origins.
+    # Default (ALLOWED_ORIGINS not set): ["*"] — permissive, matches original behavior,
+    #   preserves compatibility for existing installs.
+    # Recommended for production: set ALLOWED_ORIGINS to your domain(s) to restrict
+    #   cross-origin access and protect against session hijacking if auth is added.
     #
     # Examples:
     #   ALLOWED_ORIGINS=https://chat.example.com
     #   ALLOWED_ORIGINS=https://chat.example.com,https://app.example.com
-    #
-    # Note: "*" (wildcard) is intentionally NOT supported here because combining
-    # a wildcard origin with allow_credentials=True violates the CORS spec and
-    # creates a session hijack risk. Use explicit origins for production deployments.
-    ALLOWED_ORIGINS: List[str] = [
-        o.strip()
-        for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:8000,http://localhost:3000").split(",")
-        if o.strip() and o.strip() != "*"
-    ] or ["http://localhost:8000"]  # fallback if env var is set but empty/invalid
+    _origins_env: str = os.getenv("ALLOWED_ORIGINS", "")
+    ALLOWED_ORIGINS: List[str] = (
+        [o.strip() for o in _origins_env.split(",") if o.strip()]
+        if _origins_env.strip()
+        else ["*"]
+    )
     
     # Research/Logging Configuration
     CHAT_LOG: str = os.getenv("CHAT_LOG", "")

--- a/app/config.py
+++ b/app/config.py
@@ -33,11 +33,22 @@ class Settings:
     MAX_CONVERSATION_HISTORY: int = int(os.getenv("MAX_CONVERSATION_HISTORY", "50"))
     ENABLE_DEBUG_LOGS: bool = os.getenv("ENABLE_DEBUG_LOGS", "false").lower() == "true"
     ALLOWED_HOSTS: List[str] = os.getenv("ALLOWED_HOSTS", "*").split(",")
-    # SECURITY: Default origins restricted to localhost for local development.
-    # Set ALLOWED_ORIGINS env var to a comma-separated list of trusted origins
-    # (e.g. "https://chat.example.com,https://app.example.com").
-    # Using wildcard "*" with allow_credentials=True is insecure (CORS spec violation).
-    ALLOWED_ORIGINS: List[str] = os.getenv("ALLOWED_ORIGINS", "http://localhost:8000,http://localhost:3000").split(",")
+    # SECURITY: CORS allowed origins.
+    # Default: localhost only (safe for local development).
+    # Override with ALLOWED_ORIGINS env var — comma-separated list of trusted origins.
+    #
+    # Examples:
+    #   ALLOWED_ORIGINS=https://chat.example.com
+    #   ALLOWED_ORIGINS=https://chat.example.com,https://app.example.com
+    #
+    # Note: "*" (wildcard) is intentionally NOT supported here because combining
+    # a wildcard origin with allow_credentials=True violates the CORS spec and
+    # creates a session hijack risk. Use explicit origins for production deployments.
+    ALLOWED_ORIGINS: List[str] = [
+        o.strip()
+        for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:8000,http://localhost:3000").split(",")
+        if o.strip() and o.strip() != "*"
+    ] or ["http://localhost:8000"]  # fallback if env var is set but empty/invalid
     
     # Research/Logging Configuration
     CHAT_LOG: str = os.getenv("CHAT_LOG", "")

--- a/app/config.py
+++ b/app/config.py
@@ -43,11 +43,21 @@ class Settings:
     #   ALLOWED_ORIGINS=https://chat.example.com
     #   ALLOWED_ORIGINS=https://chat.example.com,https://app.example.com
     _origins_env: str = os.getenv("ALLOWED_ORIGINS", "")
-    ALLOWED_ORIGINS: List[str] = (
+    _parsed_origins: List[str] = (
         [o.strip() for o in _origins_env.split(",") if o.strip()]
         if _origins_env.strip()
         else ["*"]
     )
+    # Normalize: if "*" appears alongside explicit origins, treat as wildcard.
+    # Mixing wildcard with named origins is invalid per CORS spec when
+    # credentials are enabled.
+    if "*" in _parsed_origins and len(_parsed_origins) > 1:
+        logger.warning(
+            "⚠️  ALLOWED_ORIGINS contains '*' alongside explicit origins — "
+            "normalizing to wildcard-only. Remove '*' if you meant to restrict."
+        )
+        _parsed_origins = ["*"]
+    ALLOWED_ORIGINS: List[str] = _parsed_origins
     
     # Research/Logging Configuration
     CHAT_LOG: str = os.getenv("CHAT_LOG", "")

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -14,9 +14,9 @@ def setup_security_middleware(app):
     if Settings.ALLOWED_HOSTS != ["*"]:
         app.add_middleware(TrustedHostMiddleware, allowed_hosts=Settings.ALLOWED_HOSTS)
     
-    # CORS: behavior depends on whether ALLOWED_ORIGINS is explicitly configured.
-    # - Not set (default): allow_origins=["*"] preserves compatibility with existing installs.
-    # - Set via env var: restrict to listed origins and disable credentials on wildcard.
+    # CORS: behavior depends on whether ALLOWED_ORIGINS is restricted (not wildcard).
+    # - Wildcard origins ["*"]: preserves compatibility with existing installs.
+    # - Listed origins: restrict cross-origin access, enable credentials.
     cors_restricted = Settings.ALLOWED_ORIGINS != ["*"]
     app.add_middleware(
         CORSMiddleware,

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -14,13 +14,16 @@ def setup_security_middleware(app):
     if Settings.ALLOWED_HOSTS != ["*"]:
         app.add_middleware(TrustedHostMiddleware, allowed_hosts=Settings.ALLOWED_HOSTS)
     
-    # Add CORS middleware
+    # CORS: behavior depends on whether ALLOWED_ORIGINS is explicitly configured.
+    # - Not set (default): allow_origins=["*"] preserves compatibility with existing installs.
+    # - Set via env var: restrict to listed origins and disable credentials on wildcard.
+    cors_restricted = Settings.ALLOWED_ORIGINS != ["*"]
     app.add_middleware(
         CORSMiddleware,
         allow_origins=Settings.ALLOWED_ORIGINS,
-        # SECURITY: allow_credentials=False by default. Enable only if cookie-based
-        # auth is required and origins are explicitly restricted (not wildcard).
-        allow_credentials=False,
+        # allow_credentials requires explicit origins (not wildcard) per CORS spec.
+        # Only enable when origins are restricted.
+        allow_credentials=cors_restricted,
         allow_methods=["GET", "POST", "DELETE"],
         allow_headers=["*"],
     )

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -18,7 +18,9 @@ def setup_security_middleware(app):
     app.add_middleware(
         CORSMiddleware,
         allow_origins=Settings.ALLOWED_ORIGINS,
-        allow_credentials=True,
+        # SECURITY: allow_credentials=False by default. Enable only if cookie-based
+        # auth is required and origins are explicitly restricted (not wildcard).
+        allow_credentials=False,
         allow_methods=["GET", "POST", "DELETE"],
         allow_headers=["*"],
     )


### PR DESCRIPTION
## Summary
Fixes #8 by making CORS restriction opt-in via `ALLOWED_ORIGINS` environment variable. Existing installs are unaffected — default behavior is unchanged.

## Behavior

| `ALLOWED_ORIGINS` set? | `allow_origins` | `allow_credentials` |
|------------------------|-----------------|---------------------|
| No (default) | `["*"]` — original behavior | `False` |
| Yes | Your explicit list | `True` (safe with explicit origins) |

## For production deployments
Add to your `.env` or `docker-compose.yml`:
```bash
# Single domain
ALLOWED_ORIGINS=https://chat.example.com

# Multiple domains  
ALLOWED_ORIGINS=https://chat.example.com,https://app.example.com
```

## Why bother?
Without explicit origins, any website a user visits can make cross-origin requests to your TinyChat instance using their browser session. If authentication is ever added (cookies, tokens), this becomes a session hijack vector. Setting `ALLOWED_ORIGINS` closes that door.

## No breaking changes
- Existing installs with no `ALLOWED_ORIGINS` set: behavior identical to before
- `allow_credentials=False` on wildcard (browser requires this per CORS spec anyway)

## Closes
Closes #8

---
*PR by [@jasonacox-sam](https://github.com/jasonacox-sam) — security assessment follow-up*