### PR TITLE
feat: System prompt presets

### DIFF
--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -479,3 +479,288 @@
     background: #f8f9fa;
     font-weight: 600;
 }
+
+/* System Prompt Presets */
+
+.system-prompt-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.system-prompt-group select {
+    flex: 1;
+    min-width: 120px;
+}
+
+.edit-prompts-btn {
+    padding: 4px 10px;
+    background: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.2s;
+}
+
+.edit-prompts-btn:hover {
+    background: #5a6268;
+}
+
+/* System Prompt Modal */
+
+.system-prompt-modal .modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 9999;
+}
+
+.system-prompt-modal .modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    z-index: 10000;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.system-prompt-modal .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.system-prompt-modal .modal-header h3 {
+    margin: 0;
+    font-size: 18px;
+    color: #333;
+}
+
+.system-prompt-modal .modal-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #666;
+    padding: 4px 8px;
+    line-height: 1;
+}
+
+.system-prompt-modal .modal-close:hover {
+    color: #333;
+}
+
+.system-prompt-modal .modal-body {
+    padding: 16px 24px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.system-prompt-modal .modal-footer {
+    padding: 16px 24px;
+    border-top: 1px solid #e5e7eb;
+}
+
+/* Preset List */
+
+.preset-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.preset-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e5e7eb;
+}
+
+.preset-item-info {
+    flex: 1;
+    min-width: 0;
+    margin-right: 12px;
+}
+
+.preset-item-name {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    font-size: 14px;
+    color: #333;
+}
+
+.preset-badge {
+    font-size: 10px;
+    background: #e5e7eb;
+    color: #666;
+    padding: 2px 6px;
+    border-radius: 10px;
+    font-weight: 400;
+}
+
+.preset-item-preview {
+    display: block;
+    font-size: 12px;
+    color: #666;
+    margin-top: 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.preset-item-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.preset-item-actions .btn-edit {
+    padding: 4px 10px;
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.preset-item-actions .btn-edit:hover {
+    background: #0056b3;
+}
+
+.preset-item-actions .btn-delete {
+    padding: 4px 10px;
+    background: #dc3545;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.preset-item-actions .btn-delete:hover {
+    background: #c82333;
+}
+
+/* Preset Editor */
+
+.preset-editor {
+    padding: 16px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e5e7eb;
+}
+
+.editor-field {
+    margin-bottom: 12px;
+}
+
+.editor-field label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: #333;
+    margin-bottom: 4px;
+}
+
+.editor-field input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+.editor-field textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 14px;
+    font-family: inherit;
+    resize: vertical;
+    min-height: 100px;
+    box-sizing: border-box;
+}
+
+.editor-field input:focus,
+.editor-field textarea:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.editor-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.editor-actions .btn-save {
+    padding: 8px 16px;
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.editor-actions .btn-save:hover {
+    background: #0056b3;
+}
+
+.editor-actions .btn-cancel {
+    padding: 8px 16px;
+    background: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.editor-actions .btn-cancel:hover {
+    background: #5a6268;
+}
+
+/* Add Preset Button */
+
+.btn-add {
+    padding: 8px 16px;
+    background: #28a745;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.btn-add:hover {
+    background: #218838;
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -75,6 +75,13 @@
                         <option value="">Loading...</option>
                     </select>
                 </div>
+                <div class="setting-group system-prompt-group">
+                    <label for="systemPromptSelect">System Prompt:</label>
+                    <select id="systemPromptSelect">
+                        <option value="default">Default</option>
+                    </select>
+                    <button class="edit-prompts-btn" id="editPromptsBtn" title="Manage presets">Edit</button>
+                </div>
                 <div class="checkbox-row">
                     <div class="setting-group">
                         <input type="checkbox" id="markdownToggle" checked>
@@ -146,6 +153,7 @@
     <script src="/static/js/utils/storage-adapter.js"></script>
     <script src="/static/js/config.js"></script>
     <script src="/static/js/utils/storage.js"></script>
+    <script src="/static/js/utils/system-prompts.js"></script>
     <script src="/static/js/utils/markdown.js"></script>
     <script src="/static/js/utils/file-upload.js"></script>
     <script src="/static/js/components/rlm-security.js"></script>

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -65,6 +65,17 @@ async function setupEventListeners() {
         await saveModelPreference(this.value);
     });
 
+    // System prompt preset listeners
+    const systemPromptSelect = document.getElementById('systemPromptSelect');
+    systemPromptSelect.addEventListener('change', async function() {
+        await systemPrompts.select(this.value);
+    });
+
+    const editPromptsBtn = document.getElementById('editPromptsBtn');
+    editPromptsBtn.addEventListener('click', function() {
+        systemPrompts.showEditModal();
+    });
+
     // RLM toggle listener - with passcode protection
     const rlmToggle = document.getElementById('rlmToggle');
     const rlmThinkingToggle = document.getElementById('rlmThinkingToggle');
@@ -162,7 +173,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     
     // Initialize RLM security
     await rlmSecurity.initialize();
-    
+
+    // Initialize system prompt presets
+    await systemPrompts.initialize();
+
     // Track session for analytics
     try {
         const sessionResponse = await fetch('/api/session' + (sessionId ? `?session_id=${sessionId}` : ''));

--- a/app/static/js/components/chat.js
+++ b/app/static/js/components/chat.js
@@ -129,7 +129,7 @@ async function sendMessage() {
                 role: m.role,
                 content: m.content
             };
-            
+
             // Only include image data for the most recent N images
             if (imageIndices.includes(index)) {
                 // Include user-uploaded image data if present
@@ -151,15 +151,24 @@ async function sendMessage() {
                     }
                 }
             }
-            
+
             // Only include document data for the most recent N documents
             if (documentIndices.includes(index) && m.document) {
                 msg.document = m.document;
             }
-            
+
             return msg;
         });
-        
+
+        // Prepend system prompt if a preset is selected
+        const systemPromptContent = systemPrompts.getSelectedContent();
+        if (systemPromptContent && systemPrompts.selectedId !== 'none') {
+            apiMessages.unshift({
+                role: 'system',
+                content: systemPromptContent
+            });
+        }
+
         const response = await fetch('/api/chat/stream', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/app/static/js/config.js
+++ b/app/static/js/config.js
@@ -7,6 +7,8 @@ const MODEL_PREF_KEY = 'tinychat_selected_model';
 const RLM_ENABLED_KEY = 'tinychat_rlm_enabled';
 const RLM_THINKING_KEY = 'tinychat_rlm_thinking_enabled';
 const SESSION_ID_KEY = 'tinychat_session_id';
+const SYSTEM_PROMPTS_KEY = 'tinychat_system_prompts';
+const SELECTED_PROMPT_KEY = 'tinychat_selected_prompt';
 
 // Global state
 let appConfig = null;

--- a/app/static/js/utils/system-prompts.js
+++ b/app/static/js/utils/system-prompts.js
@@ -1,0 +1,400 @@
+// System Prompt Presets - CRUD operations and UI management
+
+// Built-in presets (cannot be deleted, but can be overridden)
+const BUILT_IN_PRESETS = [
+    {
+        id: 'default',
+        name: 'Default',
+        content: 'You are a helpful assistant.',
+        builtIn: true
+    },
+    {
+        id: 'concise',
+        name: 'Concise',
+        content: 'You are a helpful assistant. Be concise and direct in your responses. Avoid unnecessary filler words or lengthy explanations unless asked for more detail.',
+        builtIn: true
+    },
+    {
+        id: 'creative',
+        name: 'Creative',
+        content: 'You are a creative and imaginative assistant. Think outside the box, offer unique perspectives, and use vivid language. Be expressive and engaging in your responses.',
+        builtIn: true
+    }
+];
+
+// System prompts manager
+const systemPrompts = {
+    presets: [],
+    selectedId: null,
+
+    /**
+     * Initialize presets from storage, merging with built-ins
+     */
+    async initialize() {
+        const stored = await storageAdapter.getItem(SYSTEM_PROMPTS_KEY);
+
+        if (stored && Array.isArray(stored)) {
+            // Merge: keep built-ins as base, layer user customizations on top
+            const userPresets = stored.filter(p => !p.builtIn);
+            this.presets = [...BUILT_IN_PRESETS, ...userPresets];
+        } else {
+            this.presets = [...BUILT_IN_PRESETS];
+        }
+
+        // Load selected preset
+        this.selectedId = await storageAdapter.getItem(SELECTED_PROMPT_KEY);
+        if (!this.selectedId) {
+            this.selectedId = 'default';
+        }
+
+        this.populateDropdown();
+        return this.presets;
+    },
+
+    /**
+     * Get all presets
+     */
+    getAll() {
+        return this.presets;
+    },
+
+    /**
+     * Get a preset by ID
+     */
+    getById(id) {
+        return this.presets.find(p => p.id === id) || null;
+    },
+
+    /**
+     * Get the currently selected preset
+     */
+    getSelected() {
+        return this.getById(this.selectedId) || this.presets[0];
+    },
+
+    /**
+     * Get the system prompt content for the selected preset
+     */
+    getSelectedContent() {
+        const preset = this.getSelected();
+        return preset ? preset.content : '';
+    },
+
+    /**
+     * Select a preset by ID
+     */
+    async select(id) {
+        this.selectedId = id;
+        await storageAdapter.setItem(SELECTED_PROMPT_KEY, id);
+    },
+
+    /**
+     * Add a new custom preset
+     */
+    async add(name, content) {
+        const preset = {
+            id: generateUUID(),
+            name: name.trim(),
+            content: content.trim(),
+            builtIn: false
+        };
+        this.presets.push(preset);
+        await this.save();
+        this.populateDropdown();
+        return preset;
+    },
+
+    /**
+     * Update an existing preset
+     */
+    async update(id, name, content) {
+        const preset = this.getById(id);
+        if (!preset) return null;
+
+        preset.name = name.trim();
+        preset.content = content.trim();
+        await this.save();
+        this.populateDropdown();
+        return preset;
+    },
+
+    /**
+     * Delete a custom preset (built-ins cannot be deleted)
+     */
+    async delete(id) {
+        const preset = this.getById(id);
+        if (!preset || preset.builtIn) return false;
+
+        this.presets = this.presets.filter(p => p.id !== id);
+
+        // If deleted preset was selected, revert to default
+        if (this.selectedId === id) {
+            this.selectedId = 'default';
+            await storageAdapter.setItem(SELECTED_PROMPT_KEY, 'default');
+        }
+
+        await this.save();
+        this.populateDropdown();
+        return true;
+    },
+
+    /**
+     * Persist user presets to storage
+     */
+    async save() {
+        // Only save user-created presets (built-ins are always loaded from code)
+        const userPresets = this.presets.filter(p => !p.builtIn);
+        await storageAdapter.setItem(SYSTEM_PROMPTS_KEY, userPresets);
+    },
+
+    /**
+     * Populate the dropdown in the UI
+     */
+    populateDropdown() {
+        const select = document.getElementById('systemPromptSelect');
+        if (!select) return;
+
+        select.innerHTML = '';
+
+        // Add "None" option
+        const noneOption = document.createElement('option');
+        noneOption.value = 'none';
+        noneOption.textContent = '(None)';
+        if (this.selectedId === 'none') noneOption.selected = true;
+        select.appendChild(noneOption);
+
+        // Add built-in group
+        const builtInGroup = document.createElement('optgroup');
+        builtInGroup.label = 'Built-in';
+        this.presets.filter(p => p.builtIn).forEach(preset => {
+            const option = document.createElement('option');
+            option.value = preset.id;
+            option.textContent = preset.name;
+            if (preset.id === this.selectedId) option.selected = true;
+            builtInGroup.appendChild(option);
+        });
+        select.appendChild(builtInGroup);
+
+        // Add custom group if any exist
+        const customPresets = this.presets.filter(p => !p.builtIn);
+        if (customPresets.length > 0) {
+            const customGroup = document.createElement('optgroup');
+            customGroup.label = 'Custom';
+            customPresets.forEach(preset => {
+                const option = document.createElement('option');
+                option.value = preset.id;
+                option.textContent = preset.name;
+                if (preset.id === this.selectedId) option.selected = true;
+                customGroup.appendChild(option);
+            });
+            select.appendChild(customGroup);
+        }
+    },
+
+    /**
+     * Show the edit modal for managing presets
+     */
+    showEditModal() {
+        // Remove existing modal if any
+        const existing = document.getElementById('systemPromptModal');
+        if (existing) existing.remove();
+
+        const modal = document.createElement('div');
+        modal.id = 'systemPromptModal';
+        modal.className = 'system-prompt-modal';
+        modal.innerHTML = `
+            <div class="modal-overlay"></div>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3>Manage System Prompts</h3>
+                    <button class="modal-close" title="Close">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div class="preset-list" id="presetList"></div>
+                    <div class="preset-editor" id="presetEditor" style="display: none;">
+                        <div class="editor-field">
+                            <label for="presetName">Name:</label>
+                            <input type="text" id="presetName" placeholder="Preset name" maxlength="50">
+                        </div>
+                        <div class="editor-field">
+                            <label for="presetContent">System Prompt:</label>
+                            <textarea id="presetContent" placeholder="Enter the system prompt content..." rows="6"></textarea>
+                        </div>
+                        <div class="editor-actions">
+                            <button class="btn-save" id="presetSaveBtn">Save</button>
+                            <button class="btn-cancel" id="presetCancelBtn">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn-add" id="addPresetBtn">+ New Preset</button>
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(modal);
+
+        // Bind events
+        modal.querySelector('.modal-overlay').onclick = () => this.closeEditModal();
+        modal.querySelector('.modal-close').onclick = () => this.closeEditModal();
+        modal.querySelector('#addPresetBtn').onclick = () => this.showEditor(null);
+
+        // ESC to close
+        const handleEscape = (e) => {
+            if (e.key === 'Escape') {
+                this.closeEditModal();
+                document.removeEventListener('keydown', handleEscape);
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+
+        this.renderPresetList();
+    },
+
+    /**
+     * Render the list of presets in the modal
+     */
+    renderPresetList() {
+        const list = document.getElementById('presetList');
+        if (!list) return;
+
+        list.innerHTML = '';
+        this.presets.forEach(preset => {
+            const item = document.createElement('div');
+            item.className = 'preset-item';
+
+            const info = document.createElement('div');
+            info.className = 'preset-item-info';
+
+            const name = document.createElement('span');
+            name.className = 'preset-item-name';
+            name.textContent = preset.name;
+            if (preset.builtIn) {
+                const badge = document.createElement('span');
+                badge.className = 'preset-badge';
+                badge.textContent = 'built-in';
+                name.appendChild(badge);
+            }
+
+            const preview = document.createElement('span');
+            preview.className = 'preset-item-preview';
+            preview.textContent = preset.content.substring(0, 80) + (preset.content.length > 80 ? '...' : '');
+
+            info.appendChild(name);
+            info.appendChild(preview);
+
+            const actions = document.createElement('div');
+            actions.className = 'preset-item-actions';
+
+            const editBtn = document.createElement('button');
+            editBtn.className = 'btn-edit';
+            editBtn.textContent = 'Edit';
+            editBtn.onclick = () => this.showEditor(preset.id);
+            actions.appendChild(editBtn);
+
+            if (!preset.builtIn) {
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'btn-delete';
+                deleteBtn.textContent = 'Delete';
+                deleteBtn.onclick = () => this.confirmDelete(preset.id, preset.name);
+                actions.appendChild(deleteBtn);
+            }
+
+            item.appendChild(info);
+            item.appendChild(actions);
+            list.appendChild(item);
+        });
+    },
+
+    /**
+     * Show the editor panel for creating/editing a preset
+     */
+    showEditor(presetId) {
+        const editor = document.getElementById('presetEditor');
+        const list = document.getElementById('presetList');
+        const addBtn = document.getElementById('addPresetBtn');
+        const nameInput = document.getElementById('presetName');
+        const contentInput = document.getElementById('presetContent');
+
+        if (!editor) return;
+
+        editor.style.display = 'block';
+        list.style.display = 'none';
+        addBtn.style.display = 'none';
+
+        if (presetId) {
+            const preset = this.getById(presetId);
+            if (preset) {
+                nameInput.value = preset.name;
+                contentInput.value = preset.content;
+            }
+        } else {
+            nameInput.value = '';
+            contentInput.value = '';
+        }
+
+        // Focus name input
+        nameInput.focus();
+
+        // Save handler
+        const saveBtn = document.getElementById('presetSaveBtn');
+        saveBtn.onclick = async () => {
+            const name = nameInput.value.trim();
+            const content = contentInput.value.trim();
+
+            if (!name) {
+                nameInput.focus();
+                return;
+            }
+            if (!content) {
+                contentInput.focus();
+                return;
+            }
+
+            if (presetId) {
+                await this.update(presetId, name, content);
+            } else {
+                await this.add(name, content);
+            }
+
+            this.hideEditor();
+        };
+
+        // Cancel handler
+        const cancelBtn = document.getElementById('presetCancelBtn');
+        cancelBtn.onclick = () => this.hideEditor();
+    },
+
+    /**
+     * Hide the editor and show the list again
+     */
+    hideEditor() {
+        const editor = document.getElementById('presetEditor');
+        const list = document.getElementById('presetList');
+        const addBtn = document.getElementById('addPresetBtn');
+
+        if (editor) editor.style.display = 'none';
+        if (list) list.style.display = 'block';
+        if (addBtn) addBtn.style.display = 'inline-block';
+
+        this.renderPresetList();
+    },
+
+    /**
+     * Confirm and delete a preset
+     */
+    async confirmDelete(id, name) {
+        if (confirm(`Delete preset "${name}"? This cannot be undone.`)) {
+            await this.delete(id);
+            this.renderPresetList();
+        }
+    },
+
+    /**
+     * Close the edit modal
+     */
+    closeEditModal() {
+        const modal = document.getElementById('systemPromptModal');
+        if (modal) modal.remove();
+    }
+};

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development and testing dependencies
+-r requirements.txt
+
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+httpx>=0.27.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared test fixtures for TinyChat."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# Set required environment variables before importing the app
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+os.environ.setdefault("OPENAI_API_URL", "http://localhost:11434/v1")
+os.environ.setdefault("ALLOW_SYSTEM_MESSAGES", "true")
+
+from app.main import app  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def client():
+    """Async HTTP test client backed by the FastAPI app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/tests/test_system_prompts.py
+++ b/tests/test_system_prompts.py
@@ -1,0 +1,89 @@
+"""Tests for system prompt presets and related API behavior."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_config_endpoint_returns_success(client):
+    """GET /api/config should return 200 with expected configuration keys."""
+    response = await client.get("/api/config")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "available_models" in data
+    assert "default_model" in data
+    assert "default_temperature" in data
+    assert "version" in data
+
+
+@pytest.mark.asyncio
+async def test_config_endpoint_contains_model_list(client):
+    """GET /api/config should include a non-empty list of available models."""
+    response = await client.get("/api/config")
+    data = response.json()
+
+    assert isinstance(data["available_models"], list)
+    assert len(data["available_models"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_with_system_message(client):
+    """POST /api/chat/stream with a system message prepended should stream successfully.
+
+    When ALLOW_SYSTEM_MESSAGES=true (set in conftest), the server should accept
+    a messages array containing a system role message followed by a user message
+    and return a streaming response.
+    """
+
+    async def fake_stream(messages, temperature, model):
+        """Simulate LLM streaming a single chunk."""
+        yield f"data: {json.dumps({'content': 'Hello from the assistant'})}\n\n"
+
+    with patch("app.api.v1.chat.LLMService.stream_completion", side_effect=fake_stream):
+        response = await client.post(
+            "/api/chat/stream",
+            json={
+                "messages": [
+                    {"role": "system", "content": "You are a helpful coding assistant."},
+                    {"role": "user", "content": "Say hello"},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers.get("content-type", "")
+
+    # Parse the streamed SSE body
+    body = response.text
+    assert "Hello from the assistant" in body
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_system_message_passed_to_llm(client):
+    """The system message should be included in messages forwarded to the LLM service."""
+
+    captured_messages = []
+
+    async def capturing_stream(messages, temperature, model):
+        captured_messages.extend(messages)
+        yield f"data: {json.dumps({'content': 'ok'})}\n\n"
+
+    with patch("app.api.v1.chat.LLMService.stream_completion", side_effect=capturing_stream):
+        with patch("app.api.v1.chat.LLMService.inject_document_context", side_effect=lambda msgs: msgs):
+            await client.post(
+                "/api/chat/stream",
+                json={
+                    "messages": [
+                        {"role": "system", "content": "You are a pirate."},
+                        {"role": "user", "content": "Ahoy"},
+                    ],
+                },
+            )
+
+    # The system message should have been preserved (ALLOW_SYSTEM_MESSAGES=true)
+    system_msgs = [m for m in captured_messages if m.get("role") == "system"]
+    assert len(system_msgs) >= 1
+    assert any("pirate" in m["content"] for m in system_msgs)


### PR DESCRIPTION
## Summary
- Adds a dropdown in the chat header for selecting system prompt presets
- Ships with 3 built-in presets (Default, Concise, Creative)
- Users can add/edit/delete custom presets via a modal editor
- Selected preset is prepended as a system message before sending to the API
- Preferences persist client-side via storageAdapter (IndexedDB)

## Implementation
- New file: `app/static/js/utils/system-prompts.js` (CRUD manager)
- Modified: `index.html`, `config.js`, `chat.js`, `app.js`, `components.css`
- Added: `tests/test_system_prompts.py` (4 tests), `requirements-dev.txt`

## Test plan
- [x] Preset dropdown appears in settings bar
- [x] Built-in presets populate on first load
- [x] Custom presets can be created/edited/deleted
- [x] Selected preset persists across sessions
- [x] System message correctly prepended to API requests
- [x] "(None)" selection sends no system message
- [x] pytest passes (4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)