### PR TITLE
feat: Paste-to-image vision support

### DIFF
--- a/app/api/schemas/chat.py
+++ b/app/api/schemas/chat.py
@@ -62,17 +62,47 @@ class ChatRequest(BaseModel):
     def validate_messages(cls, v):
         """
         Validate message structure and content.
-        
+
         Checks that each message has required fields, valid role,
         and content within length limits. Also validates optional image fields.
+
+        Content may be a string (plain text) or an array of content parts
+        (OpenAI multimodal format for vision), e.g.:
+        [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "data:..."}}]
         """
         for msg in v:
             if 'role' not in msg or 'content' not in msg:
                 raise ValueError("Each message must have 'role' and 'content'")
             if msg['role'] not in ['user', 'assistant', 'system']:
                 raise ValueError("Role must be 'user', 'assistant', or 'system'")
-            if len(msg['content']) > Settings.MAX_MESSAGE_LENGTH:
-                raise ValueError(f"Message content too long (max {Settings.MAX_MESSAGE_LENGTH})")
+
+            content = msg['content']
+
+            # Content can be a string or an array (OpenAI multimodal format)
+            if isinstance(content, str):
+                if len(content) > Settings.MAX_MESSAGE_LENGTH:
+                    raise ValueError(f"Message content too long (max {Settings.MAX_MESSAGE_LENGTH})")
+            elif isinstance(content, list):
+                # Validate multimodal content array
+                for part in content:
+                    if not isinstance(part, dict) or 'type' not in part:
+                        raise ValueError("Each content part must have a 'type' field")
+                    if part['type'] == 'text':
+                        if 'text' not in part:
+                            raise ValueError("Text content part must have a 'text' field")
+                        if len(part['text']) > Settings.MAX_MESSAGE_LENGTH:
+                            raise ValueError(f"Text content too long (max {Settings.MAX_MESSAGE_LENGTH})")
+                    elif part['type'] == 'image_url':
+                        if 'image_url' not in part or 'url' not in part['image_url']:
+                            raise ValueError("image_url content part must have 'image_url.url'")
+                        url = part['image_url']['url']
+                        # Accept data URIs (base64 images) and remote URLs
+                        if not (url.startswith('data:image/') or url.startswith('http://') or url.startswith('https://')):
+                            raise ValueError("image_url must be a data URI or HTTP(S) URL")
+                    else:
+                        raise ValueError(f"Unknown content part type: {part['type']}")
+            else:
+                raise ValueError("Message content must be a string or array of content parts")
             
             # Validate optional image fields
             if 'image' in msg:

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -86,7 +86,17 @@ async def chat_stream(request: Request, chat_request: ChatRequest = None):
         await StateManager.track_session(chat_request.session_id)
     
     # Check if this is an image generation request
-    last_message = chat_request.messages[-1]["content"] if chat_request.messages else ""
+    # Content may be a string or multimodal array — extract text for command detection
+    last_content = chat_request.messages[-1]["content"] if chat_request.messages else ""
+    if isinstance(last_content, list):
+        # Extract text from multimodal content array
+        last_message = ""
+        for part in last_content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                last_message = part.get("text", "")
+                break
+    else:
+        last_message = last_content
     last_message_lower = last_message.strip().lower()
     is_image_request = last_message_lower.startswith("@image") or last_message_lower.startswith("/image")
     

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -175,7 +175,7 @@ Answer the user's questions based on the above context."""
     def format_message_for_vision_api(message: Dict) -> Dict:
         """
         Format message with image for OpenAI-compatible vision APIs.
-        
+
         OpenAI vision format:
         {
             "role": "user",
@@ -184,26 +184,38 @@ Answer the user's questions based on the above context."""
                 {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
             ]
         }
-        
+
         This format works with:
         - OpenAI GPT-4 Vision models
         - Any OpenAI-compatible API that supports vision (LM Studio, Ollama, etc.)
-        
+
+        Handles three cases:
+        1. Content is already a multimodal array (pass through as-is)
+        2. Message has separate 'image' field (convert to array format)
+        3. Plain text message (return string content)
+
         Args:
-            message: Message dict with optional 'image' and 'image_type' fields
-            
+            message: Message dict with optional 'image' and 'image_type' fields.
+                     Content may be a string or already a multimodal array.
+
         Returns:
             Formatted message dict for API
         """
+        content = message.get("content", "")
+
+        # If content is already a multimodal array, pass through
+        if isinstance(content, list):
+            return {"role": message["role"], "content": content}
+
         if not message.get('image'):
             # No image, return as plain text message
-            return {"role": message["role"], "content": message["content"]}
-        
+            return {"role": message["role"], "content": content}
+
         # Format with image using OpenAI's content array format
         return {
             "role": message["role"],
             "content": [
-                {"type": "text", "text": message["content"]},
+                {"type": "text", "text": content},
                 {
                     "type": "image_url",
                     "image_url": {

--- a/app/static/js/utils/file-upload.js
+++ b/app/static/js/utils/file-upload.js
@@ -13,24 +13,51 @@ function initializeFileHandlers() {
     const fileInput = document.getElementById('imageInput'); // Keep same ID for backward compatibility
     const inputContainer = document.querySelector('.input-container');
     const messagesArea = document.getElementById('messages');
-    
+    const messageInput = document.getElementById('messageInput');
+
     // File input change handler
     if (fileInput) {
         fileInput.addEventListener('change', handleFileSelect);
     }
-    
+
+    // Paste handler for clipboard images (Ctrl+V / Cmd+V)
+    if (messageInput) {
+        messageInput.addEventListener('paste', handlePaste);
+    }
+
     // Drag and drop handlers for input container
     if (inputContainer) {
         inputContainer.addEventListener('dragover', handleDragOver);
         inputContainer.addEventListener('dragleave', handleDragLeave);
         inputContainer.addEventListener('drop', handleDrop);
     }
-    
+
     // Drag and drop handlers for messages area (conversation thread)
     if (messagesArea) {
         messagesArea.addEventListener('dragover', handleDragOver);
         messagesArea.addEventListener('dragleave', handleDragLeave);
         messagesArea.addEventListener('drop', handleDrop);
+    }
+}
+
+/**
+ * Handle paste event to detect clipboard images.
+ * Supports Ctrl+V / Cmd+V with image data on clipboard.
+ */
+async function handlePaste(e) {
+    const clipboardData = e.clipboardData || window.clipboardData;
+    if (!clipboardData || !clipboardData.items) return;
+
+    // Look for image items in clipboard
+    for (const item of clipboardData.items) {
+        if (item.type.startsWith('image/')) {
+            e.preventDefault(); // Prevent pasting image as text
+            const file = item.getAsFile();
+            if (file) {
+                await processImageFile(file);
+            }
+            return; // Only handle first image
+        }
     }
 }
 
@@ -87,28 +114,33 @@ async function processImageFile(file) {
         showError('Please select a valid image file (JPEG, PNG, GIF, or WebP)');
         return;
     }
-    
+
     // Validate file size (max 10MB to avoid localStorage limits)
     const maxSize = 10 * 1024 * 1024; // 10MB
     if (file.size > maxSize) {
         showError('Image too large. Please select an image under 10MB.');
         return;
     }
-    
+
+    // Generate a display name (clipboard pastes often have generic names like "image.png")
+    const fileName = (file.name && file.name !== 'image.png' && file.name !== 'blob')
+        ? file.name
+        : `Pasted image (${file.type.split('/')[1]})`;
+
     // Convert to base64
     try {
         const base64 = await fileToBase64(file);
-        
-        // Compress/resize if needed
+
+        // Resize for vision (max 1024px on longest side)
         const compressed = await compressImageIfNeeded(base64, file.type);
-        
+
         attachedImage = {
             data: compressed,
             type: file.type,
-            fileName: file.name
+            fileName: fileName
         };
-        
-        showImagePreview(compressed, file.type, file.name);
+
+        showImagePreview(compressed, file.type, fileName);
     } catch (error) {
         console.error('Error processing image:', error);
         showError('Failed to process image. Please try again.');
@@ -132,59 +164,66 @@ function fileToBase64(file) {
 }
 
 /**
- * Compress image if it exceeds size threshold.
+ * Resize image for vision API (max 1024px on longest side).
+ * Always resizes to keep payloads reasonable for LLM vision endpoints.
  */
-async function compressImageIfNeeded(base64Data, mimeType) {
-    // If image is small enough, return as-is
-    const sizeInBytes = (base64Data.length * 3) / 4; // Approximate size
-    const maxSize = 5 * 1024 * 1024; // 5MB threshold for compression
-    
-    if (sizeInBytes < maxSize) {
-        console.log(`Image size OK: ${(sizeInBytes / 1024 / 1024).toFixed(2)}MB`);
-        return base64Data;
-    }
-    
-    console.log(`Compressing image: ${(sizeInBytes / 1024 / 1024).toFixed(2)}MB`);
-    
-    // Compress using canvas
+async function resizeImageForVision(base64Data, mimeType) {
+    const maxDimension = 1024;
+
     return new Promise((resolve) => {
         const img = new Image();
         img.onload = () => {
-            const canvas = document.createElement('canvas');
-            
-            // Calculate new dimensions (max 2048px on longest side)
             let width = img.width;
             let height = img.height;
-            const maxDimension = 2048;
-            
-            if (width > maxDimension || height > maxDimension) {
-                if (width > height) {
-                    height = (height * maxDimension) / width;
-                    width = maxDimension;
-                } else {
-                    width = (width * maxDimension) / height;
-                    height = maxDimension;
-                }
-                console.log(`Resizing from ${img.width}x${img.height} to ${Math.round(width)}x${Math.round(height)}`);
+
+            // Only resize if larger than max dimension
+            if (width <= maxDimension && height <= maxDimension) {
+                const sizeInBytes = (base64Data.length * 3) / 4;
+                console.log(`Image ${width}x${height} within limits (${(sizeInBytes / 1024).toFixed(0)}KB)`);
+                resolve(base64Data);
+                return;
             }
-            
+
+            // Scale down preserving aspect ratio
+            if (width > height) {
+                height = Math.round((height * maxDimension) / width);
+                width = maxDimension;
+            } else {
+                width = Math.round((width * maxDimension) / height);
+                height = maxDimension;
+            }
+
+            console.log(`Resizing from ${img.width}x${img.height} to ${width}x${height} for vision`);
+
+            const canvas = document.createElement('canvas');
             canvas.width = width;
             canvas.height = height;
-            
+
             const ctx = canvas.getContext('2d');
             ctx.drawImage(img, 0, 0, width, height);
-            
-            // Convert back to base64 with compression
-            const compressedDataURL = canvas.toDataURL(mimeType, 0.85);
+
+            // Use JPEG for smaller size unless it's PNG with transparency
+            const outputType = (mimeType === 'image/png') ? 'image/png' : 'image/jpeg';
+            const quality = (outputType === 'image/jpeg') ? 0.85 : undefined;
+            const compressedDataURL = canvas.toDataURL(outputType, quality);
             const compressedBase64 = compressedDataURL.split(',')[1];
-            
+
             const newSize = (compressedBase64.length * 3) / 4;
-            console.log(`Compressed to: ${(newSize / 1024 / 1024).toFixed(2)}MB`);
-            
+            console.log(`Resized to ${width}x${height}: ${(newSize / 1024).toFixed(0)}KB`);
+
             resolve(compressedBase64);
         };
         img.src = `data:${mimeType};base64,${base64Data}`;
     });
+}
+
+/**
+ * Compress image if it exceeds size threshold.
+ * Also applies vision resize (max 1024px) to keep payloads manageable.
+ */
+async function compressImageIfNeeded(base64Data, mimeType) {
+    // Always resize for vision (max 1024px on longest side)
+    return resizeImageForVision(base64Data, mimeType);
 }
 
 /**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development and testing dependencies
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+httpx>=0.27.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared pytest fixtures for TinyChat tests."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    """Create a FastAPI test client."""
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,172 @@
+"""Tests for vision/multimodal content support in chat schema."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.schemas.chat import ChatRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal valid base64-encoded 1x1 white PNG (truncated for brevity)
+TINY_PNG_B64 = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
+    "2mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg=="
+)
+
+
+def _make_request(**overrides):
+    """Build a minimal valid ChatRequest dict with sensible defaults."""
+    data = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "model": None,
+    }
+    data.update(overrides)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests: multimodal content (vision)
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalContent:
+    """Tests that the chat schema accepts OpenAI-style multimodal content arrays."""
+
+    def test_content_array_with_text_and_image_url(self):
+        """Schema accepts a content array containing text + image_url parts."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": TINY_PNG_B64},
+                    },
+                ],
+            }
+        ]
+        req = ChatRequest(**_make_request(messages=messages))
+        assert req.messages == messages
+
+    def test_content_array_text_only(self):
+        """Schema accepts a content array with only text parts."""
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Just text in an array"}],
+            }
+        ]
+        req = ChatRequest(**_make_request(messages=messages))
+        assert req.messages == messages
+
+    def test_content_array_with_https_image_url(self):
+        """Schema accepts an https image URL (not just data URIs)."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/photo.jpg"},
+                    },
+                ],
+            }
+        ]
+        req = ChatRequest(**_make_request(messages=messages))
+        assert req.messages[0]["content"][1]["image_url"]["url"] == "https://example.com/photo.jpg"
+
+    def test_content_array_rejects_invalid_image_url_scheme(self):
+        """Schema rejects image URLs that aren't data URI or HTTP(S)."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "ftp://evil.com/img.png"},
+                    },
+                ],
+            }
+        ]
+        with pytest.raises(ValidationError, match="data URI or HTTP"):
+            ChatRequest(**_make_request(messages=messages))
+
+    def test_content_array_rejects_missing_url(self):
+        """Schema rejects image_url part missing the url field."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {}},
+                ],
+            }
+        ]
+        with pytest.raises(ValidationError, match="image_url.url"):
+            ChatRequest(**_make_request(messages=messages))
+
+    def test_content_array_rejects_unknown_type(self):
+        """Schema rejects content parts with an unknown type."""
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "video", "url": "https://example.com/v.mp4"}],
+            }
+        ]
+        with pytest.raises(ValidationError, match="Unknown content part type"):
+            ChatRequest(**_make_request(messages=messages))
+
+    def test_image_request_does_not_crash_validation(self):
+        """Full multimodal request passes validation without exceptions."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What do you see?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": TINY_PNG_B64},
+                    },
+                ],
+            }
+        ]
+        # Should not raise
+        req = ChatRequest(**_make_request(messages=messages))
+        assert len(req.messages) == 1
+        assert len(req.messages[0]["content"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: backwards compatibility (plain string content)
+# ---------------------------------------------------------------------------
+
+
+class TestPlainStringContent:
+    """Ensure plain string content still works (backwards compat)."""
+
+    def test_plain_string_content(self):
+        """Schema accepts a plain string as message content."""
+        messages = [{"role": "user", "content": "Hello, world!"}]
+        req = ChatRequest(**_make_request(messages=messages))
+        assert req.messages[0]["content"] == "Hello, world!"
+
+    def test_multi_turn_plain_string(self):
+        """Schema accepts multi-turn conversation with string content."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        req = ChatRequest(**_make_request(messages=messages))
+        assert len(req.messages) == 4
+
+    def test_rejects_invalid_content_type(self):
+        """Schema rejects content that is neither string nor list."""
+        messages = [{"role": "user", "content": 12345}]
+        with pytest.raises(ValidationError, match="string or array"):
+            ChatRequest(**_make_request(messages=messages))


### PR DESCRIPTION
## Summary
- Adds clipboard paste (Ctrl+V / Cmd+V) support for sending images to vision-capable models
- Images are resized client-side to max 1024px and sent as base64 in OpenAI multimodal format
- Backend schema updated to accept both string and array content (multimodal messages)

## Implementation
- Frontend: paste event handler in `file-upload.js`, flows through existing image preview pipeline
- Backend: `schemas/chat.py` accepts array content, `chat.py` handles multimodal extraction, `llm_service.py` passes through array format
- Added: `tests/test_vision.py` (10 tests), `requirements-dev.txt`

## Test plan
- [x] Pasting an image from clipboard shows preview thumbnail
- [x] Image resized to max 1024px before sending
- [x] Multimodal content array sent in correct OpenAI format
- [x] Plain string messages still work (backwards compatible)
- [x] Remove button clears the pasted image
- [x] Drag-and-drop images also work
- [x] pytest passes (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)