### PR TITLE
feat: Token usage counter

### DIFF
--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -279,7 +279,8 @@ Answer the user's questions based on the above context."""
             "model": model,
             "messages": formatted_messages,
             "temperature": temperature,
-            "stream": True
+            "stream": True,
+            "stream_options": {"include_usage": True}
         }
         
         # Log the complete request details at DEBUG level
@@ -345,14 +346,20 @@ Answer the user's questions based on the above context."""
                     line_count = 0
                     async for line in response.aiter_lines():
                         line_count += 1
-                        
+
                         if line.startswith("data: "):
                             data = line[6:]  # Remove "data: " prefix
                             if data == "[DONE]":
                                 break
-                            
+
                             try:
                                 chunk = json.loads(data)
+
+                                # Check for usage data (sent as final chunk with stream_options)
+                                if "usage" in chunk and chunk["usage"]:
+                                    usage = chunk["usage"]
+                                    yield f"data: {json.dumps({'usage': usage})}\n\n"
+
                                 if "choices" in chunk and chunk["choices"]:
                                     delta = chunk["choices"][0].get("delta", {})
                                     if "content" in delta:
@@ -361,7 +368,7 @@ Answer the user's questions based on the above context."""
                             except json.JSONDecodeError as e:
                                 logger.warning(f"Failed to parse JSON chunk: {data} - Error: {e}")
                                 continue
-                    
+
                     logger.debug(f"Stream completed: {line_count} lines received")
                                 
         except httpx.HTTPStatusError as e:

--- a/app/static/css/chat.css
+++ b/app/static/css/chat.css
@@ -261,3 +261,18 @@
 .image-modal-close:hover {
     background: white;
 }
+
+/* Token usage display - per message */
+.token-usage {
+    font-size: 11px;
+    color: #999;
+    margin-top: 4px;
+    padding: 0 15px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Token total in footer */
+.token-total {
+    color: #6c757d;
+    font-size: 12px;
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -139,6 +139,7 @@
 
         <div class="footer" id="footer">
             TinyChat v<span id="version">...</span> | <a href="https://github.com/jasonacox/tinychat" target="_blank">GitHub</a>
+            <span id="tokenTotalWrap" style="display: none;"> | <span id="tokenTotal" class="token-total"></span></span>
         </div>
     </div>
 

--- a/app/static/js/components/chat.js
+++ b/app/static/js/components/chat.js
@@ -3,6 +3,45 @@
 let currentConversationId = null;
 let isStreaming = false;
 
+// Running token total for the current conversation
+let conversationTokenTotal = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
+function updateTokenTotalDisplay() {
+    const wrap = document.getElementById('tokenTotalWrap');
+    const el = document.getElementById('tokenTotal');
+    if (!el || !wrap) return;
+    if (conversationTokenTotal.total_tokens === 0) {
+        wrap.style.display = 'none';
+    } else {
+        wrap.style.display = 'inline';
+        el.textContent = `${conversationTokenTotal.total_tokens.toLocaleString()} tokens used`;
+    }
+}
+
+function resetTokenTotal() {
+    conversationTokenTotal = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+    updateTokenTotalDisplay();
+}
+
+function addToTokenTotal(usage) {
+    conversationTokenTotal.prompt_tokens += usage.prompt_tokens || 0;
+    conversationTokenTotal.completion_tokens += usage.completion_tokens || 0;
+    conversationTokenTotal.total_tokens += usage.total_tokens || 0;
+    updateTokenTotalDisplay();
+}
+
+function recalcTokenTotal(messages) {
+    conversationTokenTotal = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+    for (const msg of messages) {
+        if (msg.usage) {
+            conversationTokenTotal.prompt_tokens += msg.usage.prompt_tokens || 0;
+            conversationTokenTotal.completion_tokens += msg.usage.completion_tokens || 0;
+            conversationTokenTotal.total_tokens += msg.usage.total_tokens || 0;
+        }
+    }
+    updateTokenTotalDisplay();
+}
+
 // Helper function to get current model name for display
 function getCurrentModelName(model = null) {
     // If a specific model is provided (from stored message), use it
@@ -208,11 +247,12 @@ async function sendMessage() {
 async function handleStreamResponse(response, conversation, markdownEnabled, selectedModelName) {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
-    
+
     let assistantMessageElement = null;
     let assistantContent = '';
     let errorOccurred = false;
     let buffer = '';  // Buffer for incomplete lines
+    let usageData = null;  // Token usage from API
     
     try {
         while (true) {
@@ -285,7 +325,12 @@ async function handleStreamResponse(response, conversation, markdownEnabled, sel
                             rlmStatusIndicator.textContent = '🧠 ' + parsed.rlm_status;
                             rlmStatusIndicator.style.display = 'block';
                         }
-                        
+
+                        // Handle token usage data
+                        if (parsed.usage) {
+                            usageData = parsed.usage;
+                        }
+
                         if (parsed.content) {
                             if (!assistantMessageElement) {
                                 assistantMessageElement = await addMessageToUI('assistant', '', null, true);
@@ -356,7 +401,7 @@ async function handleStreamResponse(response, conversation, markdownEnabled, sel
     } finally {
         // Hide RLM status indicator
         document.getElementById('rlmStatus').style.display = 'none';
-        
+
         // Only save assistant message if we got content and no error occurred
         if (assistantContent && !errorOccurred) {
             const assistantMessage = {
@@ -365,7 +410,17 @@ async function handleStreamResponse(response, conversation, markdownEnabled, sel
                 timestamp: new Date().toISOString(),
                 model: selectedModelName  // Store which model generated this response
             };
-            
+
+            // Store token usage if available
+            if (usageData) {
+                assistantMessage.usage = usageData;
+                addToTokenTotal(usageData);
+                // Show token count below the message
+                if (assistantMessageElement) {
+                    appendTokenDisplay(assistantMessageElement, usageData);
+                }
+            }
+
             // If this response included an image, store it for display purposes
             // Mark it so we can filter it out when sending back to API
             if (window._lastGeneratedImage) {
@@ -373,7 +428,7 @@ async function handleStreamResponse(response, conversation, markdownEnabled, sel
                 assistantMessage.has_image = true;
                 window._lastGeneratedImage = null;  // Clear after storing
             }
-            
+
             conversation.messages.push(assistantMessage);
             conversation.last_updated = new Date().toISOString();
             await saveConversation(currentConversationId, conversation);
@@ -381,7 +436,7 @@ async function handleStreamResponse(response, conversation, markdownEnabled, sel
     }
 }
 
-async function addMessageToUI(role, content, timestamp, useMarkdown = false, fileData = null, model = null) {
+async function addMessageToUI(role, content, timestamp, useMarkdown = false, fileData = null, model = null, usage = null) {
     const container = document.getElementById('messages');
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${role}`;
@@ -519,16 +574,32 @@ async function addMessageToUI(role, content, timestamp, useMarkdown = false, fil
     
     messageDiv.appendChild(messageHeader);
     messageDiv.appendChild(messageContent);
-    
+
+    // Show token usage if available (for historical messages)
+    if (usage) {
+        appendTokenDisplay(messageDiv, usage);
+    }
+
     // Clear welcome message if it exists
     if (container.children.length === 1 && container.firstElementChild.style.textAlign === 'center') {
         container.innerHTML = '';
     }
-    
+
     container.appendChild(messageDiv);
     scrollToBottom();
-    
+
     return messageDiv;
+}
+
+function appendTokenDisplay(messageElement, usage) {
+    if (!usage || !usage.total_tokens) return;
+    const tokenDiv = document.createElement('div');
+    tokenDiv.className = 'token-usage';
+    const prompt = usage.prompt_tokens || 0;
+    const completion = usage.completion_tokens || 0;
+    const total = usage.total_tokens || 0;
+    tokenDiv.textContent = `${prompt.toLocaleString()} prompt + ${completion.toLocaleString()} completion = ${total.toLocaleString()} tokens`;
+    messageElement.appendChild(tokenDiv);
 }
 
 function showError(message) {

--- a/app/static/js/components/sidebar.js
+++ b/app/static/js/components/sidebar.js
@@ -45,18 +45,21 @@ async function createNewConversation() {
         created: new Date().toISOString(),
         last_updated: new Date().toISOString()
     };
-    
+
     await saveConversation(conversationId, conversation);
     currentConversationId = conversationId;
-    
+
+    // Reset token counter for new conversation
+    resetTokenTotal();
+
     document.getElementById('messages').innerHTML = `
         <div style="text-align: center; color: #999; margin-top: 50px;">
             New conversation started! Type a message to begin.
         </div>
     `;
-    
+
     await loadConversations();
-    
+
     // Set focus to message input for immediate typing
     document.getElementById('messageInput').focus();
 }
@@ -83,21 +86,25 @@ async function loadConversation(conversationId) {
     
     const container = document.getElementById('messages');
     container.innerHTML = '';
-    
+
+    // Recalculate token totals from stored usage data
+    recalcTokenTotal(conversation.messages);
+
     // Use for...of instead of forEach to support async/await
     for (const message of conversation.messages) {
         // For assistant messages with generated images, we need special handling
         if (message.role === 'assistant' && message.has_image && message.image_data) {
             // Add the text message first
             const messageElement = await addMessageToUI(
-                message.role, 
-                message.content, 
-                message.timestamp, 
+                message.role,
+                message.content,
+                message.timestamp,
                 true,  // useMarkdown
                 null,  // no fileData yet, we'll add it separately
-                message.model  // pass stored model name
+                message.model,  // pass stored model name
+                message.usage || null  // pass stored usage data
             );
-            
+
             // Now add the image container with download button (same as during generation)
             const messageContent = messageElement.querySelector('.message-content');
             const imageContainer = createImageContainer(message.image_data);
@@ -105,7 +112,7 @@ async function loadConversation(conversationId) {
         } else {
             // Regular message handling (user messages or assistant text without images/documents)
             let fileData = null;
-            
+
             // Check for image attachment
             if (message.image && message.image_type) {
                 fileData = {
@@ -116,7 +123,7 @@ async function loadConversation(conversationId) {
                         isComplete: false  // User uploaded images need data: prefix
                     }
                 };
-            } 
+            }
             // Check for document attachment
             else if (message.document) {
                 fileData = {
@@ -124,18 +131,19 @@ async function loadConversation(conversationId) {
                     data: message.document
                 };
             }
-            
+
             await addMessageToUI(
-                message.role, 
-                message.content, 
-                message.timestamp, 
+                message.role,
+                message.content,
+                message.timestamp,
                 message.role === 'assistant',
                 fileData,
-                message.model  // pass stored model name
+                message.model,  // pass stored model name
+                message.usage || null  // pass stored usage data
             );
         }
     }
-    
+
     scrollToBottom();
 }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.24.0
+anyio[trio]>=4.0.0
+httpx>=0.27.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared test fixtures for TinyChat."""
+
+import os
+
+# Set required environment variables before importing app modules
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+os.environ.setdefault("OPENAI_API_URL", "http://localhost:9999/v1")
+os.environ.setdefault("DEFAULT_MODEL", "test-model")
+os.environ.setdefault("AVAILABLE_MODELS", "test-model,gpt-4")
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    """Async test client for the FastAPI application."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -1,0 +1,240 @@
+"""Tests for token counting / usage reporting in streaming responses."""
+
+import json
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+import pytest
+
+from app.services.llm_service import LLMService
+
+
+@pytest.mark.anyio
+async def test_stream_options_included_in_payload():
+    """stream_options with include_usage=True must be sent to the LLM backend."""
+    captured_payload = {}
+
+    async def mock_stream_handler(method, url, **kwargs):
+        """Capture the outgoing request payload."""
+        captured_payload.update(kwargs.get("json", {}))
+
+        # Return a mock streaming response with no data
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason_phrase = "OK"
+        mock_response.headers = {}
+
+        async def empty_lines():
+            yield "data: [DONE]"
+
+        mock_response.aiter_lines = empty_lines
+        mock_response.aread = AsyncMock(return_value=b"")
+        return mock_response
+
+    # Build a minimal async context manager for httpx.AsyncClient.stream
+    class FakeStreamCM:
+        def __init__(self, method, url, **kwargs):
+            self.kwargs = kwargs
+            self.method = method
+            self.url = url
+
+        async def __aenter__(self):
+            return await mock_stream_handler(self.method, self.url, **self.kwargs)
+
+        async def __aexit__(self, *args):
+            pass
+
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with patch("httpx.AsyncClient.stream", side_effect=lambda method, url, **kw: FakeStreamCM(method, url, **kw)):
+        chunks = []
+        async for chunk in LLMService.stream_completion(messages):
+            chunks.append(chunk)
+
+    # Verify stream_options is in the captured payload
+    assert "stream_options" in captured_payload, "stream_options missing from LLM request payload"
+    assert captured_payload["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.anyio
+async def test_usage_data_forwarded_in_stream():
+    """When the LLM returns a usage chunk, it should be forwarded to the client."""
+    usage_data = {
+        "prompt_tokens": 10,
+        "completion_tokens": 25,
+        "total_tokens": 35,
+    }
+
+    # Simulate SSE lines from the LLM backend
+    sse_lines = [
+        f'data: {json.dumps({"choices": [{"delta": {"content": "Hi"}}]})}',
+        f'data: {json.dumps({"choices": [], "usage": usage_data})}',
+        "data: [DONE]",
+    ]
+
+    class FakeResponse:
+        status_code = 200
+        reason_phrase = "OK"
+        headers = {}
+
+        async def aiter_lines(self):
+            for line in sse_lines:
+                yield line
+
+        async def aread(self):
+            return b""
+
+    class FakeStreamCM:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, *args):
+            pass
+
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with patch("httpx.AsyncClient.stream", side_effect=lambda *a, **kw: FakeStreamCM()):
+        chunks = []
+        async for chunk in LLMService.stream_completion(messages):
+            chunks.append(chunk)
+
+    # Parse the SSE data chunks we received
+    parsed = []
+    for chunk in chunks:
+        if chunk.startswith("data: "):
+            data_str = chunk.split("data: ", 1)[1].strip()
+            parsed.append(json.loads(data_str))
+
+    # Should have a content chunk and a usage chunk
+    content_chunks = [p for p in parsed if "content" in p]
+    usage_chunks = [p for p in parsed if "usage" in p]
+
+    assert len(content_chunks) == 1
+    assert content_chunks[0]["content"] == "Hi"
+
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["usage"] == usage_data
+
+
+@pytest.mark.anyio
+async def test_stream_works_without_usage_data():
+    """The stream should work gracefully when the LLM does not return usage info."""
+    # Simulate SSE lines WITHOUT any usage chunk
+    sse_lines = [
+        f'data: {json.dumps({"choices": [{"delta": {"content": "Hello"}}]})}',
+        f'data: {json.dumps({"choices": [{"delta": {"content": " world"}}]})}',
+        "data: [DONE]",
+    ]
+
+    class FakeResponse:
+        status_code = 200
+        reason_phrase = "OK"
+        headers = {}
+
+        async def aiter_lines(self):
+            for line in sse_lines:
+                yield line
+
+        async def aread(self):
+            return b""
+
+    class FakeStreamCM:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, *args):
+            pass
+
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with patch("httpx.AsyncClient.stream", side_effect=lambda *a, **kw: FakeStreamCM()):
+        chunks = []
+        async for chunk in LLMService.stream_completion(messages):
+            chunks.append(chunk)
+
+    # Parse the SSE data chunks
+    parsed = []
+    for chunk in chunks:
+        if chunk.startswith("data: "):
+            data_str = chunk.split("data: ", 1)[1].strip()
+            parsed.append(json.loads(data_str))
+
+    # Should have content chunks but no usage chunk
+    content_chunks = [p for p in parsed if "content" in p]
+    usage_chunks = [p for p in parsed if "usage" in p]
+
+    assert len(content_chunks) == 2
+    assert content_chunks[0]["content"] == "Hello"
+    assert content_chunks[1]["content"] == " world"
+    assert len(usage_chunks) == 0, "No usage chunk should be emitted when LLM omits usage data"
+
+
+@pytest.mark.anyio
+async def test_chat_stream_endpoint_returns_usage(client):
+    """Integration test: the /api/chat/stream endpoint forwards usage data."""
+    usage_data = {
+        "prompt_tokens": 5,
+        "completion_tokens": 12,
+        "total_tokens": 17,
+    }
+
+    sse_lines = [
+        f'data: {json.dumps({"choices": [{"delta": {"content": "Hey"}}]})}',
+        f'data: {json.dumps({"choices": [], "usage": usage_data})}',
+        "data: [DONE]",
+    ]
+
+    class FakeResponse:
+        status_code = 200
+        reason_phrase = "OK"
+        headers = {}
+
+        async def aiter_lines(self):
+            for line in sse_lines:
+                yield line
+
+        async def aread(self):
+            return b""
+
+    class FakeStreamCM:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, *args):
+            pass
+
+    with patch("httpx.AsyncClient.stream", side_effect=lambda *a, **kw: FakeStreamCM()):
+        response = await client.post(
+            "/api/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "Hi"}],
+                "model": "test-model",
+            },
+        )
+
+    assert response.status_code == 200
+
+    # Parse the streaming response body
+    body = response.text
+    events = []
+    for line in body.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            data_str = line[6:]
+            try:
+                events.append(json.loads(data_str))
+            except json.JSONDecodeError:
+                pass
+
+    usage_events = [e for e in events if "usage" in e]
+    assert len(usage_events) == 1
+    assert usage_events[0]["usage"]["total_tokens"] == 17


### PR DESCRIPTION
## Summary
- Displays per-message token usage (prompt + completion = total) below each assistant response
- Shows a running conversation total in the footer
- Gracefully degrades when the API doesn't return usage data (e.g. Ollama)

## Implementation
- Backend: adds `stream_options: {"include_usage": true}` to LLM requests, forwards usage chunk as SSE event
- Frontend: captures usage events, displays subtle gray text below messages, running total in footer
- Usage data persists in conversation storage for historical display
- Added: `tests/test_token_counter.py` (4 tests), `requirements-dev.txt`

## Test plan
- [x] `stream_options` included in outgoing LLM request
- [x] Usage data forwarded in SSE stream when available
- [x] Token count displayed below assistant messages
- [x] Running total updates in footer
- [x] No token display when API omits usage (graceful fallback)
- [x] Historical token data shown when loading saved conversations
- [x] pytest passes (4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)